### PR TITLE
feat(performance-chart): Add d3 to render performance charts

### DIFF
--- a/scripts/lib/build_perf/html/measurement_chart_d3.html
+++ b/scripts/lib/build_perf/html/measurement_chart_d3.html
@@ -1,0 +1,67 @@
+<script type="module">
+
+import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm"
+
+// Declare the chart dimensions and margins.
+const width = 928;
+const height = 500;
+const marginTop = 20;
+const marginRight = 30;
+const marginBottom = 30;
+const marginLeft = 40;
+
+// Get data 
+const rawData = [
+      {% for sample in measurement.samples %}
+        [{{ sample.commit_num }}, {{ sample.mean.gv_value() }}],
+      {% endfor %}
+    ];
+
+const convertToMinute = (time) => {
+  return time[0]*60 + time[1] + time[2]/60 + time[3]/3600;
+}
+
+// Assuming the array quantities are durations in the format [hours, minutes, seconds, milliseconds]
+const data = rawData.map(([commit, quantity]) => ({commit, quantity: (Array.isArray(quantity) ? convertToMinute(quantity) : quantity)}));
+
+// Declare the x (horizontal position) scale.
+const x = d3.scaleUtc(d3.extent(data, d => d.commit), [marginLeft, width - marginRight])
+
+// Declare the y (vertical position) scale.
+const yAxisData = data.map(d => d.quantity);
+const y = d3.scaleLinear([0, d3.max(data, d => d.quantity)], [height - marginBottom, marginTop])
+            .domain(d3.extent(yAxisData))
+
+// Declare the line generator.
+const line = d3.line()
+      .x(d => x(d.commit))
+      .y(d => y(d.quantity));
+
+// Create the SVG container.
+const svg = d3.create("svg")
+      .attr("width", width)
+      .attr("height", height)
+      .attr("viewBox", [0, 0, width, height])
+      .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+// Add the x-axis.
+svg.append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(d3.axisBottom(x));
+
+// Add the y-axis.
+svg.append("g")
+    .attr("transform", `translate(${marginLeft},0)`)
+    .call(d3.axisLeft(y));
+
+// Append a path for the line.
+svg.append("path")
+      .attr("fill", "none")
+      .attr("stroke", "steelblue")
+      .attr("stroke-width", 1.5)
+      .attr("d", line(data));
+
+// Append the SVG element.
+{{chart_elem_id}}.append(svg.node());
+
+</script>

--- a/scripts/lib/build_perf/html/measurement_chart_d3.html
+++ b/scripts/lib/build_perf/html/measurement_chart_d3.html
@@ -1,7 +1,5 @@
 <script type="module">
 
-import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm"
-
 // Declare the chart dimensions and margins.
 const width = 928;
 const height = 500;

--- a/scripts/lib/build_perf/html/report.html
+++ b/scripts/lib/build_perf/html/report.html
@@ -3,18 +3,14 @@
 <head>
 {# Scripts, for visualization#}
 <!--START-OF-SCRIPTS-->
-<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-<script type="text/javascript">
-google.charts.load('current', {'packages':['corechart']});
-var chartsDrawing = 0;
-</script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 
 {# Render measurement result charts #}
 {% for test in test_data %}
   {% if test.status == 'SUCCESS' %}
     {% for measurement in test.measurements %}
       {% set chart_elem_id = test.name + '_' + measurement.name + '_chart' %}
-      {% include 'measurement_chart.html' %}
+      {% include 'measurement_chart_d3.html' %}
     {% endfor %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR:
- sets up d3 using the vanilla JS example: https://d3js.org/getting-started#d3-in-vanilla-html
- generates charts from the `measurement_chart_d3` file

![image](https://github.com/yoctoproject/poky/assets/13760198/cbbbd5c0-52c0-48fc-9045-4a2a0147f872)
