### PR TITLE
Fix dependency issue as Intel's repo got archived

### DIFF
--- a/meta/recipes-support/bmap-tools/bmap-tools_git.bb
+++ b/meta/recipes-support/bmap-tools/bmap-tools_git.bb
@@ -9,7 +9,7 @@ SECTION = "console/utils"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/intel/${BPN};branch=main;protocol=https"
+SRC_URI = "git://github.com/yoctoproject/bmaptool.git;branch=main;protocol=https"
 
 SRCREV = "c0673962a8ec1624b5189dc1d24f33fe4f06785a"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Intel's https://github.com/intel/bmap-tools repo got archived and the project wouldn't build, so I had to update the source to get it working again.