### PR TITLE
linux-yocto: added patch to fix "maybe-uninitialized" warning with gcc 14

### DIFF
--- a/meta/recipes-kernel/linux/linux-yocto/0001-Fix-Wmaybe-uninitialized-warnings-errors.patch
+++ b/meta/recipes-kernel/linux/linux-yocto/0001-Fix-Wmaybe-uninitialized-warnings-errors.patch
@@ -1,0 +1,27 @@
+From 3d7da18f665037150b9b3ae1c098852ab766bc18 Mon Sep 17 00:00:00 2001
+From: Jan Kircher <jan.kircher@leica-microsystems.com>
+Date: Tue, 29 Oct 2024 17:33:57 +0100
+Subject: [PATCH] Fix -Wmaybe-uninitialized warnings/errors
+
+Upstream-Status: Pending
+
+---
+ tools/lib/subcmd/parse-options.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/lib/subcmd/parse-options.c b/tools/lib/subcmd/parse-options.c
+index 4b60ec03b0bb..6a7785d0f15a 100644
+--- a/tools/lib/subcmd/parse-options.c
++++ b/tools/lib/subcmd/parse-options.c
+@@ -809,7 +809,7 @@ static int option__cmp(const void *va, const void *vb)
+ static struct option *options__order(const struct option *opts)
+ {
+ 	int nr_opts = 0, nr_group = 0, nr_parent = 0, len;
+-	const struct option *o, *p = opts;
++	const struct option *o = NULL, *p = opts;
+ 	struct option *opt, *ordered = NULL, *group;
+
+ 	/* flatten the options that have parents */
+--
+2.47.0
+

--- a/meta/recipes-kernel/linux/linux-yocto_6.10.bb
+++ b/meta/recipes-kernel/linux/linux-yocto_6.10.bb
@@ -41,7 +41,8 @@ PN:class-devupstream = "linux-yocto-upstream"
 KBRANCH:class-devupstream = "v6.10/base"
 
 SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;name=machine;branch=${KBRANCH};protocol=https \
-           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.10;destsuffix=${KMETA};protocol=https"
+           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.10;destsuffix=${KMETA};protocol=https \
+           file://0001-Fix-Wmaybe-uninitialized-warnings-errors.patch"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 LINUX_VERSION ?= "6.10.14"


### PR DESCRIPTION
Styhead [added support for Ubuntu 24.10](https://docs.yoctoproject.org/dev/migration-guides/migration-5.1.html#supported-distributions) that ships with gcc 14. This version of gcc produces an error when compiling the linux kernel:

```
In function 'memcpy',
    inlined from 'options__order' at parse-options.c:834:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10: error: 'o' may be used uninitialized [-Werror=maybe-uninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
parse-options.c: In function 'options__order':
parse-options.c:812:30: note: 'o' was declared here
  812 |         const struct option *o, *p = opts;
      |                              ^
cc1: all warnings being treated as errors
```

This patch simply initializes `o` with `NULL`.