### PR TITLE
bitbake: knotty/progressbar: Optimize footer update and prints

### DIFF
--- a/bitbake/lib/progressbar/progressbar.py
+++ b/bitbake/lib/progressbar/progressbar.py
@@ -246,7 +246,7 @@ class ProgressBar(object):
                                     for w in self.widgets)
 
 
-    def update(self, value=None):
+    def update(self, value=None, fd_print=True):
         """Updates the ProgressBar to a new value."""
 
         if value is not None and value is not UnknownLength:
@@ -266,8 +266,9 @@ class ProgressBar(object):
         self.seconds_elapsed = now - self.start_time
         self.next_update = self.currval + self.update_interval
         output = self._format_line()
-        self.fd.write(output + '\r')
-        self.fd.flush()
+        if fd_print:
+            self.fd.write(output + '\r')
+            self.fd.flush()
         self.last_update_time = now
         return output
 

--- a/bitbake/lib/progressbar/progressbar.py
+++ b/bitbake/lib/progressbar/progressbar.py
@@ -121,7 +121,7 @@ class ProgressBar(object):
             # STDOUT is the default writing descriptor with a value of 1.
             # STDERR is the default error descriptor with a value of 2.
             # Sure, fd is a resizable file descriptor, let's allow to
-            # use for _handle resize().
+            # use for self._handle_resize().
             self._fd_console = fd
             self._handle_resize(None, None)
             signal.signal(signal.SIGWINCH, self._handle_resize)

--- a/bitbake/lib/progressbar/progressbar.py
+++ b/bitbake/lib/progressbar/progressbar.py
@@ -246,7 +246,7 @@ class ProgressBar(object):
                                     for w in self.widgets)
 
 
-    def update(self, value=None, fd_print=True):
+    def update(self, value=None):
         """Updates the ProgressBar to a new value."""
 
         if value is not None and value is not UnknownLength:
@@ -266,9 +266,8 @@ class ProgressBar(object):
         self.seconds_elapsed = now - self.start_time
         self.next_update = self.currval + self.update_interval
         output = self._format_line()
-        if fd_print:
-            self.fd.write(output + '\r')
-            self.fd.flush()
+        self.fd.write(output + '\r')
+        self.fd.flush()
         self.last_update_time = now
         return output
 


### PR DESCRIPTION
- Optimizing footer update to use a StringIO buffer before print() called.
- Cleaning and refactoring prints, print() was eliminated from loops.
- Forced update footer to not happen faster than 20 Hz.