### PR TITLE
libxcrypt-compat: Remove libcrypt.so to fix conflict with libcrypt

### DIFF
--- a/meta/recipes-core/libxcrypt/libxcrypt-compat_4.4.33.bb
+++ b/meta/recipes-core/libxcrypt/libxcrypt-compat_4.4.33.bb
@@ -13,6 +13,7 @@ API = "--enable-obsolete-api"
 do_install:append () {
 	rm -rf ${D}${includedir}
 	rm -rf ${D}${libdir}/pkgconfig
+	rm -rf ${D}${libdir}/libcrypt.so
 	rm -rf ${D}${datadir}
 }
 


### PR DESCRIPTION
**Sorry for not sending the Patch to the mailinglist, but this is a real pain behind a cooperate firewall.** 

Fixed:
IMAGE_INSTALL:append = " libxcrypt-compat"

$ bitbake <image> -cpopulate_sdk
file /usr/lib/libcrypt.so from install of
libxcrypt-compat-dev-4.4.33-r0.0.aarch64 conflicts with file from package libcrypt-dev-4.4.33-r0.2.aarch64

Remove libcrypt.so like other files to fix the error.

(From scarthgap rev: 90bdd736c0ddfe650d6e93727aba03fc8f1cfe94)