### PR TITLE
module.bbclass: add KBUILD_EXTRA_SYMBOLS to install

### DIFF
--- a/meta/classes-recipe/module.bbclass
+++ b/meta/classes-recipe/module.bbclass
@@ -65,6 +65,7 @@ module_do_install() {
 	           CC="${KERNEL_CC}" LD="${KERNEL_LD}" OBJCOPY="${KERNEL_OBJCOPY}" \
 	           STRIP="${KERNEL_STRIP}" \
 	           O=${STAGING_KERNEL_BUILDDIR} \
+		   KBUILD_EXTRA_SYMBOLS="${KBUILD_EXTRA_SYMBOLS}" \
 	           ${MODULES_INSTALL_TARGET}
 
 	if [ ! -e "${B}/${MODULES_MODULE_SYMVERS_LOCATION}/Module.symvers" ] ; then


### PR DESCRIPTION
Symbols are used during install as well, adding KBUILD_EXTRA_SYMBOLS enables successful installation.

```
| DEBUG: Executing shell function do_install
| NOTE: make -j 22 KERNEL_SRC=xxx/kernel-source -C xxx/drivers KDIR=xxx/kernel-source DEPMOD=echo MODLIB=xxx/image/lib/modules/6.6.75-yocto-standard-00189-g530c419bc9db INSTALL_FW_PATH=xxx/image/lib/firmware CC=aarch64-poky-linux-gcc   -fuse-ld=bfd -fcanon-prefix-map  LD=aarch64-poky-linux-ld.bfd   OBJCOPY=aarch64-poky-linux-objcopy  STRIP=aarch64-poky-linux-strip O=xxx/kernel-build-artifacts modules_install
| make: Entering directory 'xxx/drivers'
| make -C xxx/kernel-source M=xxx/drivers modules
| make[1]: Entering directory 'xxx/kernel-source'
| make[2]: Entering directory 'xxx/kernel-build-artifacts'
|   MODPOST xxx/drivers/Module.symvers
| ERROR: modpost: "xxx" [xxx/xxx.ko] undefined!
```